### PR TITLE
[add] #65 イベント実行回数をカウントする配列と、配列を管理するプログラムを追加

### DIFF
--- a/Assets/Scripts/Events/EventLaunch.cs
+++ b/Assets/Scripts/Events/EventLaunch.cs
@@ -16,7 +16,7 @@ public class EventLaunch : MonoBehaviour
         if (collision.gameObject.CompareTag("Player"))
         {
             isPlayerColliding = true;
-            Debug.Log("approched");
+            // Debug.Log("approched");
         }
     }
 
@@ -27,7 +27,7 @@ public class EventLaunch : MonoBehaviour
         if (collision.gameObject.CompareTag("Player"))
         {
             isPlayerColliding = false;
-            Debug.Log("distant");
+            // Debug.Log("distant");
         }
     }
 
@@ -37,9 +37,8 @@ public class EventLaunch : MonoBehaviour
         if (isPlayerColliding && Input.GetKeyDown(KeyCode.Space) && GameRoot.I.isActive_Move == true)
         {
             GameRoot.I.isEvent = true;
-            GameRoot.I.nowLabel = 0;
-            
-            Debug.Log("Launch the Event");
+            GameRoot.I.eventCount[0]++;     // 総イベント実行回数を1増加
+
             // UnityEventに登録されたすべてのメソッドを実行
             OnInteraction?.Invoke();
         }

--- a/Assets/Scripts/Events/EventList.cs
+++ b/Assets/Scripts/Events/EventList.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections;
+using System;
 
 // Event一覧を管理するスクリプト
 // EventLaunchをアタッチした各オブジェクトに設定した関数が呼び出される
@@ -8,12 +9,26 @@ public class EventList : MonoBehaviour
     private string[] eventMessage;
     public const string SHOW_YESNO_OPTIONS = "SHOW_YESNO_OPTIONS";
 
+    // イベントカウントの配列要素を増加させる
+    private void addeventCount(int eventNum)
+    {
+        if (eventNum >= GameRoot.I.eventCount.Length)
+        {
+            // 配列サイズを2まで増加
+            Array.Resize(ref GameRoot.I.eventCount, eventNum + 1);
+        }
+        GameRoot.I.eventCount[eventNum]++;
+    }
+
     public void StartEV01()
     {
+        addeventCount(1);
         StartCoroutine(ev01bench());
     }
+
     public void StartEV02()
     {
+        addeventCount(2);
         StartCoroutine(ev02chest());
     }
 

--- a/Assets/Scripts/GameRoot.cs
+++ b/Assets/Scripts/GameRoot.cs
@@ -5,8 +5,8 @@ public class GameRoot
 {
     // 静的プロパティで唯一のインスタンスを提供
     public static GameRoot I { get; private set; } = new GameRoot();
-    //public static GameRoot I { get; private set; }
 
+    // 制限時間
     public float currentTime;
 
     // 状態管理用のbool変数
@@ -19,17 +19,11 @@ public class GameRoot
 
     // イベント管理用の変数
     public bool selected;       // yes or no
-    public int nowLabel;        // イベント進行管理
+    public int[] eventCount = { 0 };    // イベント実行回数をカウントする配列
+    public float[] eventTime= { 0 };   // イベントを実行した時間
 
     // 役職管理用の変数
     public string ThisRole;     // 診断した役職の結果
     public int seeking = 0, decision = 0, sensitive = 0, patience = 0, insight = 0;
 
-
-    //private void Awake()
-    //{
-    //    if (I != null && I != this) { Destroy(gameObject); return; }
-    //    I = this;
-    //    DontDestroyOnLoad(gameObject);  // シーンをまたいで生存
-    //}
 }


### PR DESCRIPTION
#65の解決。`EventList.cs`の`addeventCount(int eventNum)`で配列を管理。引数にイベントの番号を指定して使う。カウント配列中に指定番目の要素がなければ要素番目まで配列を増やす。その後対応する要素のイベント実行回数を1増やす。
例）イベント01より先に02を実行したとき、イベント1用の配列も生成される